### PR TITLE
Move copy files task after image preparation script

### DIFF
--- a/tasks/lxc_cache_preparation.yml
+++ b/tasks/lxc_cache_preparation.yml
@@ -80,15 +80,6 @@
   tags:
     - skip_ansible_lint
 
-- name: Copy files from deployment host to the container cache
-  copy:
-    src: "{{ item.src }}"
-    dest: "{{ lxc_image_cache_path }}{{ item.dest | default(item.src) }}"
-    owner: "{{ item.owner | default('root') }}"
-    group: "{{ item.group | default('root') }}"
-    mode: "{{ item.mode | default('0644') }}"
-  with_items: "{{ lxc_container_cache_files }}"
-
 - name: Cached image preparation script
   copy:
     content: |
@@ -103,6 +94,15 @@
 - name: Prepare cached image setup commands
   command: "chroot {{ lxc_image_cache_path }} /usr/local/bin/cache-prep-commands.sh"
   changed_when: false
+
+- name: Copy files from deployment host to the container cache
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ lxc_image_cache_path }}{{ item.dest | default(item.src) }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.mode | default('0644') }}"
+  with_items: "{{ lxc_container_cache_files }}"
 
 - name: Adjust sshd configuration in container
   lineinfile:


### PR DESCRIPTION
Reorder tasks to be able to copy files from deployment host to paths which are created by packages  when cache-prep-commands.sh runs.

Example: currently if we want to inject any CA certificates to LXC build chroot role would fail, because /etc/ssl directory doesn't exist.