### PR TITLE
Fix initial lxc-dnsmasq.service crash

### DIFF
--- a/tasks/lxc_net.yml
+++ b/tasks/lxc_net.yml
@@ -88,7 +88,7 @@
         state: started
         enabled: true
         execstartpres: |
-          {% set pres = ['-/usr/bin/pkill -u {{ lxc_net_dnsmasq_user }} "^dnsmasq"'] %}
+          {% set pres = ['-/usr/bin/pkill -u ' + lxc_net_dnsmasq_user + ' "^dnsmasq"'] %}
           {% if lxc_net_manage_iptables | bool %}
           {%   set _ = pres.append('/usr/local/bin/lxc-system-manage iptables-create') %}
           {% endif %}


### PR DESCRIPTION
Fixes parsing issues not replacing the variable with a proper username in the systemd service file, which leads to service crash upon first start with error `pkill: invalid user name: {{`.
The service fails to properly kill the already dnsmasq and can therefor not bind to the socket again.
A service restart will not trigger this issue, but a system reboot will.

Full error:
```
░░ The job identifier is 122.
Feb 10 17:20:17 host pkill[1089]: pkill: invalid user name: {{
Feb 10 17:20:17 host systemd[1]: Started lxc-dnsmasq.service - lxc-dnsmasq service.
░░ Subject: A start job for unit lxc-dnsmasq.service has finished successfully
░░ Defined-By: systemd
░░ Support: https://www.debian.org/support
░░ 
░░ A start job for unit lxc-dnsmasq.service has finished successfully.
░░ 
░░ The job identifier is 122.
Feb 10 17:20:17 host lxc-system-manage[1092]: Starting LXC dnsmasq.
Feb 10 17:20:17 host lxc-system-manage[1098]: dnsmasq: failed to create listening socket for 10.0.3.1: Cannot assign requested address
Feb 10 17:20:17 host dnsmasq[1098]: failed to create listening socket for 10.0.3.1: Cannot assign requested address
Feb 10 17:20:17 host dnsmasq[1098]: FAILED to start up
Feb 10 17:20:17 host systemd[1]: lxc-dnsmasq.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```